### PR TITLE
Improved FlashArray alert collection with timeline param

### DIFF
--- a/pkg/clients/array/flasharray/client.go
+++ b/pkg/clients/array/flasharray/client.go
@@ -36,9 +36,8 @@ const (
 	ArrayControllersEndpoint              = "/array?controllers=true"
 	ArrayPerformanceMetricsEndpoint       = "/array?action=monitor&size=true"
 	HostCountEndpoint                     = "/host?start=0&limit=1"
-	MessageClosedEndpoint                 = "/message?open=false"
 	MessageFlaggedEndpoint                = "/message?flagged=true"
-	MessageOpenEndpoint                   = "/message?open=true"
+	MessageTimelineEndpoint               = "/message?timeline=true"
 	SessionEndpoint                       = "/auth/session"
 	VolumeCapacityMetricsEndpoint         = "/volume?space=true"
 	VolumeCountEndpoint                   = "/volume?start=0&limit=1"
@@ -90,19 +89,14 @@ func NewClient(displayName string, managementEndpoint string, apiToken string) (
 	return &client, nil
 }
 
-// GetAlertsClosed returns only closed alert messages from the array
-func (client *Client) GetAlertsClosed() ([]*AlertResponse, error) {
-	return client.getAlerts(MessageClosedEndpoint)
-}
-
 // GetAlertsFlagged returns only flagged alert messages from the array
 func (client *Client) GetAlertsFlagged() ([]*AlertResponse, error) {
 	return client.getAlerts(MessageFlaggedEndpoint)
 }
 
-// GetAlertsOpen returns only open alert messages from the array
-func (client *Client) GetAlertsOpen() ([]*AlertResponse, error) {
-	return client.getAlerts(MessageOpenEndpoint)
+// GetAlertsTimeline returns all alert messages from the array with a "closed" response field
+func (client *Client) GetAlertsTimeline() ([]*AlertResponse, error) {
+	return client.getAlerts(MessageTimelineEndpoint)
 }
 
 // GetArrayCapacityMetrics returns all capacity metrics for the array

--- a/pkg/clients/array/flasharray/client_test.go
+++ b/pkg/clients/array/flasharray/client_test.go
@@ -56,15 +56,11 @@ func TestFlashArrayClient(t *testing.T) {
 
 	var response interface{}
 
-	response, err = client.GetAlertsClosed()
-	assert.NoError(t, err)
-	assert.NotNil(t, response)
-
 	response, err = client.GetAlertsFlagged()
 	assert.NoError(t, err)
 	assert.NotNil(t, response)
 
-	response, err = client.GetAlertsOpen()
+	response, err = client.GetAlertsTimeline()
 	assert.NoError(t, err)
 	assert.NotNil(t, response)
 

--- a/pkg/clients/array/flasharray/types.go
+++ b/pkg/clients/array/flasharray/types.go
@@ -24,9 +24,8 @@ import (
 
 // ArrayClient is the interface for the FlashArray client
 type ArrayClient interface {
-	GetAlertsClosed() ([]*AlertResponse, error)
 	GetAlertsFlagged() ([]*AlertResponse, error)
-	GetAlertsOpen() ([]*AlertResponse, error)
+	GetAlertsTimeline() ([]*AlertResponse, error)
 	GetArrayCapacityMetrics() (*ArrayCapacityMetricsResponse, error)
 	GetArrayInfo() (*ArrayInfoResponse, error)
 	GetArrayPerformanceMetrics() (*ArrayPerformanceMetricsResponse, error)
@@ -62,9 +61,8 @@ type Collector struct {
 
 // AlertResponseBundle is used to return all alerts responses together
 type AlertResponseBundle struct {
-	ClosedResponse  []*AlertResponse
-	FlaggedResponse []*AlertResponse
-	OpenResponse    []*AlertResponse
+	FlaggedResponse  []*AlertResponse
+	TimelineResponse []*AlertResponse
 }
 
 // ArrayMetricsResponseBundle is used to return all array metric responses together
@@ -87,6 +85,7 @@ type ObjectCountResponseBundle struct {
 type AlertResponse struct {
 	Actual          string `json:"actual"`
 	Category        string `json:"category"`
+	Closed          string `json:"closed"`
 	Code            uint16 `json:"code"`
 	ComponentName   string `json:"component_name"`
 	ComponentType   string `json:"component_type"`

--- a/pkg/clients/array/flashblade/collector.go
+++ b/pkg/clients/array/flashblade/collector.go
@@ -263,7 +263,6 @@ func (collector *Collector) GetArrayName() (string, error) {
 }
 
 // GetArrayTags returns the tags of the array from the API server
-// TODO: we will need to fill in a client here
 func (collector *Collector) GetArrayTags() (map[string]string, error) {
 	timer := timing.NewStageTimer("flashblade.Collector.GetArrayTags", log.Fields{"display_name": collector.DisplayName})
 	defer timer.Finish()


### PR DESCRIPTION
Using a new query parameter for the /message endpoint, collecting alerts
and marking them as open/closed is easier and bug-free.

targeting #5 