### PR TITLE
Fixed location of 'host' in ingress rules

### DIFF
--- a/deploy/helm/pure1-unplugged/charts/api-server/templates/ingress.yaml
+++ b/deploy/helm/pure1-unplugged/charts/api-server/templates/ingress.yaml
@@ -25,12 +25,12 @@ spec:
       {{- end }}
 
   rules:
-    - http:
-        {{- if $domainName }}
-        host: {{ $domainName }}
-        {{ else }}
-        # host:  ## Not specified because global.PublicAddress is an IP address
-        {{ end -}}
+    - {{- if $domainName }}
+      host: {{ $domainName }}
+      {{ else }}
+      # host:  ## Not specified because global.PublicAddress is an IP address
+      {{ end -}}
+      http:
         paths:
           - path: /api/?(.*)
             backend:

--- a/deploy/helm/pure1-unplugged/charts/auth-server/templates/api-token-ingress.yaml
+++ b/deploy/helm/pure1-unplugged/charts/auth-server/templates/api-token-ingress.yaml
@@ -25,12 +25,12 @@ spec:
       {{- end }}
 
   rules:
-    - http:
-        {{- if $domainName }}
-        host: {{ $domainName }}
-        {{ else }}
-        # host:  ## Not specified because global.PublicAddress is an IP address
-        {{ end -}}
+    - {{- if $domainName }}
+      host: {{ $domainName }}
+      {{ else }}
+      # host:  ## Not specified because global.PublicAddress is an IP address
+      {{ end -}}
+      http:
         paths:
           - path: /auth/api-token(/?.*)
             backend:

--- a/deploy/helm/pure1-unplugged/charts/auth-server/templates/main-ingress.yaml
+++ b/deploy/helm/pure1-unplugged/charts/auth-server/templates/main-ingress.yaml
@@ -23,12 +23,12 @@ spec:
       {{- end }}
 
   rules:
-    - http:
-        {{- if $domainName }}
-        host: {{ $domainName }}
-        {{ else }}
-        # host:  ## Not specified because global.PublicAddress is an IP address
-        {{ end -}}
+    - {{- if $domainName }}
+      host: {{ $domainName }}
+      {{ else }}
+      # host:  ## Not specified because global.PublicAddress is an IP address
+      {{ end -}}
+      http:
         paths:
           - path: /auth/?(.*)
             backend:

--- a/deploy/helm/pure1-unplugged/charts/dex/templates/ingress.yaml
+++ b/deploy/helm/pure1-unplugged/charts/dex/templates/ingress.yaml
@@ -21,12 +21,12 @@ spec:
       {{- end }}
 
   rules:
-    - http:
-        {{- if $domainName }}
-        host: {{ $domainName }}
-        {{ else }}
-        # host:  ## Not specified because global.PublicAddress is an IP address
-        {{ end -}}
+    - {{- if $domainName }}
+      host: {{ $domainName }}
+      {{ else }}
+      # host:  ## Not specified because global.PublicAddress is an IP address
+      {{ end -}}
+      http:
         paths:
           - path: /dex
             backend:

--- a/deploy/helm/pure1-unplugged/charts/swagger-server/templates/ingress.yaml
+++ b/deploy/helm/pure1-unplugged/charts/swagger-server/templates/ingress.yaml
@@ -27,12 +27,12 @@ spec:
       {{- end }}
 
   rules:
-    - http:
-        {{- if $domainName }}
-        host: {{ $domainName }}
-        {{ else }}
-        # host:  ## Not specified because global.PublicAddress is an IP address
-        {{ end -}}
+    - {{- if $domainName }}
+      host: {{ $domainName }}
+      {{ else }}
+      # host:  ## Not specified because global.PublicAddress is an IP address
+      {{ end -}}
+      http:
         paths:
           - path: /swagger/?(.*)
             backend:

--- a/deploy/helm/pure1-unplugged/charts/web-content/templates/dash-ingress.yaml
+++ b/deploy/helm/pure1-unplugged/charts/web-content/templates/dash-ingress.yaml
@@ -24,12 +24,12 @@ spec:
       {{- end }}
 
   rules:
-    - http:
-        {{- if $domainName }}
-        host: {{ $domainName }}
-        {{ else }}
-        # host:  ## Not specified because global.PublicAddress is an IP address
-        {{ end -}}
+    - {{- if $domainName }}
+      host: {{ $domainName }}
+      {{ else }}
+      # host:  ## Not specified because global.PublicAddress is an IP address
+      {{ end -}}
+      http:
         paths:
           - path: /
             backend:

--- a/deploy/helm/pure1-unplugged/charts/web-content/templates/login-ingress.yaml
+++ b/deploy/helm/pure1-unplugged/charts/web-content/templates/login-ingress.yaml
@@ -23,12 +23,12 @@ spec:
       {{- end }}
 
   rules:
-    - http:
-        {{- if $domainName }}
-        host: {{ $domainName }}
-        {{ else }}
-        # host:  ## Not specified because global.PublicAddress is an IP address
-        {{ end -}}
+    - {{- if $domainName }}
+      host: {{ $domainName }}
+      {{ else }}
+      # host:  ## Not specified because global.PublicAddress is an IP address
+      {{ end -}}
+      http:
         paths:
           - path: /login
             backend:

--- a/deploy/helm/pure1-unplugged/templates/elasticsearch-ingress.yaml
+++ b/deploy/helm/pure1-unplugged/templates/elasticsearch-ingress.yaml
@@ -24,12 +24,12 @@ spec:
       {{- end }}
 
   rules:
-    - http:
-        {{- if $domainName }}
-        host: {{ $domainName }}
-        {{ else }}
-        # host:  ## Not specified because global.PublicAddress is an IP address
-        {{ end -}}
+    - {{- if $domainName }}
+      host: {{ $domainName }}
+      {{ else }}
+      # host:  ## Not specified because global.PublicAddress is an IP address
+      {{ end -}}
+      http:
         paths:
           - path: /elasticsearch/?(.*)
             backend:

--- a/deploy/helm/pure1-unplugged/templates/kibana-ingress.yaml
+++ b/deploy/helm/pure1-unplugged/templates/kibana-ingress.yaml
@@ -24,12 +24,12 @@ spec:
       {{- end }}
 
   rules:
-    - http:
-        {{- if $domainName }}
-        host: {{ $domainName }}
-        {{ else }}
-        # host:  ## Not specified because global.PublicAddress is an IP address
-        {{ end -}}
+    - {{- if $domainName }}
+      host: {{ $domainName }}
+      {{ else }}
+      # host:  ## Not specified because global.PublicAddress is an IP address
+      {{ end -}}
+      http:
         paths:
           - path: /kibana/?(.*)
             backend:


### PR DESCRIPTION
Attempted fix for #9. Looks like the `host` parameter for the HTTP rules was in the wrong place, and since the route host didn't match the TLS host, it didn't use that cert and used the default instead.

WIP, waiting for build so I can test.