### PR TITLE
Added CentOS Vault as baseurl of yum repo

### DIFF
--- a/images/lorax-build/lorax.patch
+++ b/images/lorax-build/lorax.patch
@@ -11,13 +11,3 @@ index 04d13610..1c5deb7c 100644
              add_templates=None,
              add_template_vars=None,
              add_arch_templates=None,
-@@ -308,7 +308,8 @@ class Lorax(BaseLoraxClass):
-             else:
-                 logger.info("no BCJ filter for arch %s", self.arch.basearch)
-         rb.create_runtime(joinpaths(installroot,runtime),
--                          compression=compression, compressargs=compressargs)
-+                          compression=compression, compressargs=compressargs,
-+                          size=size)
- 
-         logger.info("preparing to build output tree and boot images")
-         treebuilder = TreeBuilder(product=self.product, arch=self.arch,

--- a/scripts/build/build_installer_iso.sh
+++ b/scripts/build/build_installer_iso.sh
@@ -115,6 +115,7 @@ lorax \
     --bugurl "https://support.purestorage.com/" \
     --volid ${PURE1_UNPLUGGED_VOLID} \
     --buildarch "x86_64" \
+    --rootfs-size 10 \
     ${BUILD_DIR}/lorax-results
 
 cp ${BUILD_DIR}/lorax-results/images/boot.iso ${BUILD_DIR}/${OS_NAME}-${VERSION}.iso

--- a/scripts/build/build_installer_iso.sh
+++ b/scripts/build/build_installer_iso.sh
@@ -37,6 +37,17 @@ mkdir -p ${BUILD_TMP_DIR}
 cp /etc/yum.repos.d/CentOS-Base.repo ${BUILD_TMP_DIR}/centos7-base.repo
 sed -i s/.releasever/7/g ${BUILD_TMP_DIR}/centos7-base.repo
 
+# We need to change the base URL to use the CentOS vault.
+sed -i "s/#baseurl=http:\/\/mirror.centos.org\/centos\/7/baseurl=http:\/\/vault.centos.org\/${CENTOS_VERSION}/g" ${BUILD_TMP_DIR}/centos7-base.repo
+# Disable the mirror list because the mirrors lie (they make it so we can't find packages for some reason)
+sed -i "s/mirrorlist/#mirrorlist/g" ${BUILD_TMP_DIR}/centos7-base.repo
+
+# Copy this back to use our updated version
+cp ${BUILD_TMP_DIR}/centos7-base.repo /etc/yum.repos.d/CentOS-Base.repo
+
+# Clean all just to remove any caches we may somehow have
+yum clean all
+
 # Generate our boot config RPM, which is in itself installing along with some extra configs
 mkdir -p ${BUILD_TMP_DIR}/pure1-unplugged-boot-config-rpm
 mkdir -p ${BUILD_TMP_DIR}/pure1-unplugged-boot-config-rpm/Packages


### PR DESCRIPTION
Discovered because builds were not finding all the necessary packages due to a mirror change. The old mirror had deleted all the updates and left a readme noting the deprecation. Additionally, there is no Docker version of CentOS 7.7, so just bumping to a supported version isn't an option: this seems like the best alternative.