### PR TITLE
Changed the default query size to 1000 if not specified

### DIFF
--- a/images/lorax-build/Dockerfile
+++ b/images/lorax-build/Dockerfile
@@ -32,7 +32,7 @@ RUN yum update -y && yum install -y \
 # Note we install kubeadm only so we can snag a list of its required images with the config shipped
 # for this version of kubeadm (matches the one we install with our installer iso).
 
-RUN gem install --no-ri --no-rdoc fpm
+RUN gem install --no-ri --no-rdoc fpm -f
 
 COPY images/lorax-build/lorax.conf /etc/lorax/
 

--- a/pkg/clients/elastic/arrays.go
+++ b/pkg/clients/elastic/arrays.go
@@ -40,6 +40,10 @@ func (c *Client) FindArrays(query *resources.ArrayQuery) ([]*resources.Array, er
 	searchService := c.esclient.Search(arraysIndexName).Type("_doc").Query(query.GenerateElasticQueryObject()).From(query.Offset).IgnoreUnavailable(true).AllowNoIndices(true)
 	if query.Limit > 0 {
 		searchService.Size(query.Limit)
+	} else {
+		// Default to 1000 results if not specified (should be bigger than any "practical" fleet size to ensure returning
+		// all results)
+		searchService.Size(1000)
 	}
 	if len(query.Sort) > 0 {
 		sortParam, err := query.GetSortParameter()

--- a/scripts/build/build_lorax_image.sh
+++ b/scripts/build/build_lorax_image.sh
@@ -19,6 +19,7 @@ if [[ -z "${KUBEVERSION}" ]]; then
 fi
 
 docker build \
+    --no-cache \
     -t lorax-build:${VERSION} \
     --build-arg "KUBERNETES_VERSION=${KUBEVERSION}" \
     -f ${REPO_ROOT}/images/lorax-build/Dockerfile \


### PR DESCRIPTION
This fixes a bug where fleets with >10 devices would only show the first 10 arrays (filters would show the rest).

Closes #37.